### PR TITLE
Update core.py

### DIFF
--- a/flask_sentinel/core.py
+++ b/flask_sentinel/core.py
@@ -6,7 +6,7 @@
     :copyright: (c) 2015 by Nicola Iarocci.
     :license: BSD, see LICENSE for more details.
 """
-from flask.ext.pymongo import PyMongo
+from flask_pymongo import PyMongo
 from flask_oauthlib.provider import OAuth2Provider
 from redis import StrictRedis
 


### PR DESCRIPTION
Fixes flask_sentinel/core.py:9: ExtDeprecationWarning: Importing flask.ext.pymongo is deprecated, use flask_pymongo instead.
  from flask.ext.pymongo import PyMongo